### PR TITLE
Fix potential panics in CGO calls caused by Go’s garbage collector re…

### DIFF
--- a/aho_corasick.go
+++ b/aho_corasick.go
@@ -74,6 +74,7 @@ func (ac *AhoCorasick) FindAll(input string) []Match {
 	cText := (*C.char)(unsafe.Pointer(unsafe.StringData(input)))
 	foundCount := C.long(0)
 	cMatches := C.find_iter(ac.automaton, cText, C.size_t(len(input)), &foundCount)
+	runtime.KeepAlive(input)
 	result := make([]Match, int(foundCount))
 	if foundCount > 0 {
 		goSlice := (*[1 << 30]C.AhoCorasickMatch)(unsafe.Pointer(cMatches))[:foundCount:foundCount]
@@ -97,6 +98,7 @@ func (ac *AhoCorasick) FindAll(input string) []Match {
 func (ac *AhoCorasick) FindFirst(input string) *Match {
 	cText := (*C.char)(unsafe.Pointer(unsafe.StringData(input)))
 	match := C.find(ac.automaton, cText, C.size_t(len(input)))
+	runtime.KeepAlive(input)
 	if match == nil {
 		return nil
 	}
@@ -132,5 +134,6 @@ func (ac *AhoCorasick) GetKind() AhoCorasickKind {
 func (ac *AhoCorasick) IsMatch(input string) bool {
 	cText := (*C.char)(unsafe.Pointer(unsafe.StringData(input)))
 	isMatch := C.is_match(ac.automaton, cText, C.size_t(len(input)))
+	runtime.KeepAlive(input)
 	return int(isMatch) != 0
 }


### PR DESCRIPTION
When I was using it, I encountered a panic. After analysis, I suspect it was caused by the garbage collector reclaiming memory during a CGO call, which led to a memory error. To avoid this issue, I used `runtime.KeepAlive`.
```go
runtime: bad pointer in frame github.com/tmikus/ahocorasick_rs.(*AhoCorasick).FindAll at 0xc0153a1680: 0x8
fatal error: invalid pointer found on stack
```